### PR TITLE
add TCP User Timeout param to s3 driver

### DIFF
--- a/registry/storage/driver/s3-aws/tcp_default.go
+++ b/registry/storage/driver/s3-aws/tcp_default.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package s3
+
+import (
+	"time"
+)
+
+func setTCPUserTimeout(fd uintptr, timeout time.Duration) error {
+	return nil
+}

--- a/registry/storage/driver/s3-aws/tcp_linux.go
+++ b/registry/storage/driver/s3-aws/tcp_linux.go
@@ -1,0 +1,12 @@
+package s3
+
+import (
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setTCPUserTimeout(fd uintptr, timeout time.Duration) error {
+	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, unix.TCP_USER_TIMEOUT, int(timeout.Milliseconds()))
+}


### PR DESCRIPTION
This allows customizing the [`TCP_USER_TIMEOUT`](https://man7.org/linux/man-pages/man7/tcp.7.html#:~:text=to%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20be%20portable.-,TCP_USER_TIMEOUT) value for S3 client connections through the `tcpusertimeout` parameter.